### PR TITLE
Add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: cmakelint
+    name: CMake Lint
+    description: This hook lints CMake files for style issues.
+    entry: cmakelint
+    language: python
+    types: [cmake]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ same effect:
     cmakelint.py CMakeLists.txt
     cmakelint.py --filter=-whitespace/indent CMakeLists.txt
 
+cmakelint can also be run with [pre-commit](https://pre-commit.com). Add the following configuration block to your `.pre-commit-config.yaml`:
+
+``` yaml
+  - repo: https://github.com/cmake-lint/cmake-lint
+    hooks:
+      - id: cmakelint
+```
+
 # Output status codes
 
 The program should exit with the following status codes:


### PR DESCRIPTION
[Pre-commit](https://pre-commit.com) is a tool used to manage pre-commit hooks. With this change, I add a `.pre-commit-hooks.yaml` file which lists `cmakelint` as the only tool. This makes it easy for users to integrate `cmakelint` into their pre-commit hooks.

---

 To test it locally you will need to install pre-commit: 

    $ pip install pre-commit 

To run pre-commit hooks, first locate a project with cmake files you want to lint. Add a a `.pre-commit-config.yaml` to the root directory of this project. The file specifies the hooks that you want to run. For simplicity, you can use this configuration which points to my branch to test:

``` yaml
---
repos:
  - repo: https://github.com/comkieffer/cmake-lint
    rev: pre-commit-hook
    hooks:
      - id: cmakelint
        args: [--linelength=100, --spaces=4, --filter=-readability/wonkycase]
```

Once the file is in place, enable it by running `pre-commit install` in the root directory of that project. By default, `pre-commit` will only lint staged files, but you can make it run on all files with `pre-commit run --all-files`. If linter errors are found, the tool will reject the commit. 



