### PR TITLE
add filter for specified commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Run the `--filter=` option with no filter to see available options. Currently
 these are:
 
     convention/filename
+    command
     linelength
     package/consistency
     readability/logic
@@ -50,6 +51,7 @@ these are:
 An example .cmakelintrc file would be as follows:
 
     filter=-whitespace/indent
+    filter=+command=foo
 
 With this file in your home directory, running these commands would have the
 same effect:

--- a/cmakelint/main.py
+++ b/cmakelint/main.py
@@ -448,14 +448,15 @@ def CheckForbiddenCommand(filename, linenumber, clean_lines, errors):
     if not ContainsCommand(line): # nothing to see here
         return
     command = GetCommand(line) # get command from line
-    for f in _lint_state.filters: # and for each...
-        if "command=" in f: # ... command filter
-            _f = f[1:].strip("command=").upper() # make sure both are uppercase for comparison
+    for f in _lint_state.filters: # and for each...#
+        match = re.findall(r"(?<=\+command=).*", f, flags=re.DOTALL|re.MULTILINE)
+        if len(match) > 0: # ... command filter
+            _f = match[0].upper() # make sure both are uppercase for comparison
             _command = command.upper()
             if _command == _f: # and compare if command is forbidden.
                 errors( 
                     filename,
-                    line,
+                    linenumber,
                     f[1:],
                     "Command {cmd} should not be used!".format(cmd=command)
                 )

--- a/cmakelint/main.py
+++ b/cmakelint/main.py
@@ -442,6 +442,8 @@ def CheckFindPackage(filename, linenumber, clean_lines, errors):
             _package_state.HaveUsedStandardArgs(filename, linenumber, var_name, errors)
 
 def CheckForbiddenCommand(filename, linenumber, clean_lines, errors):
+    """Checks if a forbidden command has been used.
+    """
     line = clean_lines.lines[linenumber]
     if not ContainsCommand(line): # nothing to see here
         return

--- a/test/cmakelint_test.py
+++ b/test/cmakelint_test.py
@@ -254,6 +254,21 @@ class CMakeLintTest(CMakeLintTestBase):
                                   '  foo() \n'
                                   '  foo()\n'), '')
 
+    def testFilterForbiddenCommand(self):
+        self.doTestMultiLineLint(('# lint_cmake: +command=include_directories\n'
+                                  '    include_directories(test/dir)\n' ),
+                                  'Command include_directories should not be used!'
+                                  )
+        self.doTestMultiLineLint(('# lint_cmake: +command=find_module\n'
+                                  '    find_module(test/dir)\n' ),
+                                  'Command find_module should not be used!'
+                                  )
+        self.doTestMultiLineLint(('# lint_cmake: +command=foo2\n'
+                                  '    foo(test/dir)\n'
+                                  '    foo2(test/dir)\n' ),
+                                  'Command foo2 should not be used!'
+                                  )
+
     def testBadPragma(self):
         self.doTestMultiLineLint(('# lint_cmake: I am badly formed\n'
                                   'if(TRUE)\n'


### PR DESCRIPTION
## command filter
to be able to keep a cmake project clean I would like to introduce a filter that lints on specified commands like:
```
# lint_cmake: +command=foo2
foo2(bar) # --> Error!
```

this PR is the first split from #13 