### PR TITLE
Add doc how to override filters in CMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ same effect:
     cmakelint.py CMakeLists.txt
     cmakelint.py --filter=-whitespace/indent CMakeLists.txt
 
+Filters can optionally be directly enabled/disabled from within a CMake file,
+overriding the configuration from file or CLI argument:
+
+```
+# lint_cmake: <+ or -><filter name>
+# e.g.:
+# lint_cmake: -readability/wonkycase
+# add multiple filters as list:
+# lint_cmake: <+/-><filter1>, <+/-><filter2>
+```
+
 cmakelint can also be run with [pre-commit](https://pre-commit.com). Add the following configuration block to your `.pre-commit-config.yaml`:
 
 ``` yaml


### PR DESCRIPTION
In my opinion the documentation would benefit from additional information on how to disable/add filters on a per-file basis, i.e. not via the configuration file. This was helpful for my usecase together with ROS2, where cmake-lint is integrated with ament_cmake, and overriding the configuration file is not feasible. However, sometimes still changes need to be made, for example FetchContent_Populate triggers readability/wonkycase.