### PR TITLE
Add package/stdargs filter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ these are:
     convention/filename
     linelength
     package/consistency
+    package/stdargs
     readability/logic
     readability/mixedcase
     readability/wonkycase


### PR DESCRIPTION
This patch mentions also filter package/stdargs in the README.