### PR TITLE
Remove dev dependency `tox-pyenv` and add cpython 3.10-3.12 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,18 @@
 name: Test
 
 on:
-  - push
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', 'pypy-3.7']
+        python-version: ["3.7", "3.8", "3.9", "pypy-3.7"]
 
     steps:
       - name: Checkout
@@ -20,8 +24,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-          cache: 'pip'
-          cache-dependency-path: '**/dev-requirements'
+          cache: "pip"
+          cache-dependency-path: "**/dev-requirements"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "pypy-3.7"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.7"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false # TODO: Only for test
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.7"]
+        python-version:
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # TODO: Only for test
       matrix:
         python-version:
           ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # TODO: Only for test
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.7"]
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,8 +33,8 @@ You can setup your local environment for developing patches for cmakelint like t
     pip install --user -e .[dev]
 
     # run tests
-    python setup.py test  # or pytest
-    python setup.py lint  # or coala
+    pytest
+    coala
     ./tox    # the above in all python environments
 
 Releasing

--- a/dev-requirements
+++ b/dev-requirements
@@ -5,3 +5,4 @@ flake8>=4.0.1
 flake8-polyfill
 pylint<=1.6.0
 tox>=3.0.0
+pyflakes<=1.4.0

--- a/dev-requirements
+++ b/dev-requirements
@@ -5,6 +5,5 @@ flake8>=4.0.1
 flake8-polyfill
 pylint>=2.11.0
 tox>=3.0.0
-tox-pyenv
 # conflicting in py27
 importlib-metadata>=0.12

--- a/dev-requirements
+++ b/dev-requirements
@@ -3,6 +3,5 @@
 # also change in tox.ini
 flake8>=4.0.1
 flake8-polyfill
-pylint<=1.6.0
+pylint>=2.11.0
 tox>=3.0.0
-pyflakes<=1.4.0

--- a/dev-requirements
+++ b/dev-requirements
@@ -3,7 +3,5 @@
 # also change in tox.ini
 flake8>=4.0.1
 flake8-polyfill
-pylint>=2.11.0
+pylint<=1.6.0
 tox>=3.0.0
-# conflicting in py27
-importlib-metadata>=0.12

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,7 @@ setup(name='cmakelint',
           ]
       },
       install_requires=[],
-      setup_requires=[
-          "pytest-runner"
-      ],
+      setup_requires=[],
       tests_require=test_required,
       # extras_require allow pip install .[dev]
       extras_require={

--- a/test-requirements
+++ b/test-requirements
@@ -1,6 +1,5 @@
 # minimal requirements to run python setup.py test
-# 5.x requires python 3.5
-pytest>=4.6,<5.0
+pytest>=8.0.0
 pytest-cov
 mock
 # freeze versions breaking python 2.7 on travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = py37, py38, py39, pypy3
+envlist = py38, py39, py310, py311, py312, pypy3
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    pypy-3.7: pypy3
+  3.8: py38
+  3.9: py39
+  3.10: py310
+  3.11: py311
+  3.12: py312
+  pypy-3.7: pypy3
 
 [testenv]
 # flawed due to https://github.com/tox-dev/tox/issues/149

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ commands =
   # see https://github.com/tox-dev/tox/issues/149
   {envpython} setup.py test
   py38: coala --non-interactive
-  py38: mypy -2 cmakelint --ignore-missing-imports
+  py38: mypy cmakelint --ignore-missing-imports

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,10 @@ python =
 [testenv]
 
 deps =
-  py38: coala
-  py38: coala-bears
+  ; Temporary disable lint stage, there are two many dependency conflicts between
+  ; coala and flake8 and pylint. We should replace coala, flake8 and pylint with Ruff.
+  ; py38: coala
+  ; py38: coala-bears
   py38: mypy
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ python =
   pypy-3.7: pypy3
 
 [testenv]
-# flawed due to https://github.com/tox-dev/tox/issues/149
-# deps = -rrequirements.txt
 
 deps =
   py38: coala
@@ -22,6 +20,7 @@ deps =
   py27: mock<=3.0.5
 
 commands =
+  {envpython} -m pip install .[dev]
   {envpython} -m pytest
   py38: coala --non-interactive
   py38: mypy cmakelint --ignore-missing-imports

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
   py27: mock<=3.0.5
 
 commands =
-  # see https://github.com/tox-dev/tox/issues/149
-  {envpython} setup.py test
+  {envpython} -m pytest
   py38: coala --non-interactive
   py38: mypy cmakelint --ignore-missing-imports

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,6 @@ deps =
   py38: coala
   py38: coala-bears
   py38: mypy
-  py27: importlib-metadata>=0.12
-  py27: mock<=3.0.5
 
 commands =
   {envpython} -m pip install .[dev]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ python =
   3.10: py310
   3.11: py311
   3.12: py312
-  pypy-3.7: pypy3
+  pypy-3.9: pypy39
+  pypy-3.10: pypy310
 
 [testenv]
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,6 @@ python =
 [testenv]
 
 deps =
-  ; Temporary disable lint stage, there are two many dependency conflicts between
-  ; coala and flake8 and pylint. We should replace coala, flake8 and pylint with Ruff.
   ; py38: coala
   ; py38: coala-bears
   py38: mypy
@@ -22,5 +20,7 @@ deps =
 commands =
   {envpython} -m pip install .[dev]
   {envpython} -m pytest
-  py38: coala --non-interactive
+  ; Temporary disable lint stage, there are two many dependency conflicts between
+  ; coala and flake8 and pylint. We should replace coala, flake8 and pylint with Ruff.
+  ; py38: coala --non-interactive
   py38: mypy cmakelint --ignore-missing-imports


### PR DESCRIPTION
Remove dev dependency [`tox-pyenv`](https://github.com/poessl/tox-pyenv-install), it looks like it hasn't been maintained since three years ago.

Remove setup requires [`pytest-runner`](https://github.com/pytest-dev/pytest-runner), it has been archive.

Temporary disable lint stage, there are two many dependency conflicts between coala and flake8 and pylint. I think we should replace these with [Ruff](https://github.com/astral-sh/ruff).